### PR TITLE
Allow running the server when the code lives on a readonly filesystem

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -65,6 +65,7 @@ class Config:
 
     ALLOW_SCORE_WITH_NO_SONG = True
 
+    LOG_BASE_DIR = "./log"
     ALLOW_INFO_LOG = False
     ALLOW_WARNING_LOG = False
 
@@ -85,7 +86,7 @@ class Config:
     # You can change this to make another PTT mechanism.
     BEST30_WEIGHT = 1 / 40
     RECENT10_WEIGHT = 1 / 40
-    
+
     INVASION_START_WEIGHT = 0.1
     INVASION_HARD_WEIGHT = 0.1
 
@@ -108,7 +109,7 @@ class Config:
 
 
     NOTIFICATION_EXPIRE_TIME = 3 * 60 * 1000
-    
+
 
 
 class ConfigManager:

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -87,12 +87,14 @@ class Config:
     BEST30_WEIGHT = 1 / 40
     RECENT10_WEIGHT = 1 / 40
 
+
     INVASION_START_WEIGHT = 0.1
     INVASION_HARD_WEIGHT = 0.1
 
     MAX_FRIEND_COUNT = 50
 
     WORLD_MAP_FOLDER_PATH = './database/map/'
+    WORLD_MAP_LEPHON_NELL_FOLDER_PATH = './database/map_lephon_nell'
     SONG_FILE_FOLDER_PATH = './database/songs/'
     SONGLIST_FILE_PATH = './database/songs/songlist'
     CONTENT_BUNDLE_FOLDER_PATH = './database/bundle/'
@@ -109,7 +111,6 @@ class Config:
 
 
     NOTIFICATION_EXPIRE_TIME = 3 * 60 * 1000
-
 
 
 class ConfigManager:

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -113,10 +113,13 @@ class Config:
 
 
 class ConfigManager:
-
     @staticmethod
     def load(config) -> None:
-        for k, v in config.__dict__.items():
+        ConfigManager.load_dict(config.__dict__)
+
+    @staticmethod
+    def load_dict(config) -> None:
+        for k, v in config.items():
             if k.startswith('__') or k.endswith('__'):
                 continue
             if hasattr(Config, k):

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -65,7 +65,6 @@ class Config:
 
     ALLOW_SCORE_WITH_NO_SONG = True
 
-    LOG_BASE_DIR = "./log"
     ALLOW_INFO_LOG = False
     ALLOW_WARNING_LOG = False
 
@@ -93,6 +92,7 @@ class Config:
 
     MAX_FRIEND_COUNT = 50
 
+    LOG_FOLDER_PATH = "./log"
     WORLD_MAP_FOLDER_PATH = './database/map/'
     WORLD_MAP_LEPHON_NELL_FOLDER_PATH = './database/map_lephon_nell'
     SONG_FILE_FOLDER_PATH = './database/songs/'

--- a/core/world.py
+++ b/core/world.py
@@ -55,7 +55,7 @@ class MapParser:
 
         for i in range(4):
             self.map_lephon_nell_phases[i] = os.path.join(
-                "./database/map_lephon_nell", f"{i+1}.json"
+                Config.WORLD_MAP_LEPHON_NELL_FOLDER_PATH, f"{i+1}.json"
             )
 
     def re_init(self) -> None:

--- a/main.py
+++ b/main.py
@@ -171,6 +171,7 @@ def generate_log_file_dict(level: str, filename: str) -> dict:
 
 
 def main():
+    print(Config.LOG_BASE_DIR)
     log_dict = {
         'version': 1,
         'root': {
@@ -183,7 +184,7 @@ def main():
                 'stream': 'ext://flask.logging.wsgi_errors_stream',
                 'formatter': 'default'
             },
-            "error_file": generate_log_file_dict('ERROR', './log/error.log')
+            "error_file": generate_log_file_dict('ERROR', f'{Config.LOG_BASE_DIR}/error.log')
         },
         'formatters': {
             'default': {
@@ -194,11 +195,11 @@ def main():
     if Config.ALLOW_INFO_LOG:
         log_dict['root']['handlers'].append('info_file')
         log_dict['handlers']['info_file'] = generate_log_file_dict(
-            'INFO', './log/info.log')
+            'INFO', f'{Config.LOG_BASE_DIR}/info.log')
     if Config.ALLOW_WARNING_LOG:
         log_dict['root']['handlers'].append('warning_file')
         log_dict['handlers']['warning_file'] = generate_log_file_dict(
-            'WARNING', './log/warning.log')
+            'WARNING', f'{Config.LOG_BASE_DIR}/warning.log')
 
     dictConfig(log_dict)
 

--- a/main.py
+++ b/main.py
@@ -2,8 +2,6 @@
 
 import json
 import os
-import sys
-import importlib.util
 from importlib import import_module
 
 from core.config_manager import Config, ConfigManager

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+import json
 import os
 import sys
 import importlib.util
@@ -12,15 +13,10 @@ if os.path.exists('config.py') or os.path.exists('config'):
     ConfigManager.load(import_module("config").Config)
 else:
     # Allow importing the config from a custom path given through an environment variable
-    configPath = os.environ.get("ARCAEA_CONFIG_PATH")
+    configPath = os.environ.get("ARCAEA_JSON_CONFIG_PATH")
     if os.path.exists(configPath):
-        # Taken from the python docs
-        # https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
-        spec = importlib.util.spec_from_file_location("config", configPath)
-        module = importlib.util.module_from_spec(spec)
-        sys.modules["config"] = module
-        spec.loader.exec_module(module)
-        ConfigManager.load(module.Config)
+        with open(configPath, 'r') as file:
+            ConfigManager.load_dict(json.load(file))
 
 
 if Config.DEPLOY_MODE == 'gevent':

--- a/main.py
+++ b/main.py
@@ -191,7 +191,7 @@ def main():
                 'stream': 'ext://flask.logging.wsgi_errors_stream',
                 'formatter': 'default'
             },
-            "error_file": generate_log_file_dict('ERROR', f'{Config.LOG_BASE_DIR}/error.log')
+            "error_file": generate_log_file_dict('ERROR', f'{Config.LOG_FOLDER_PATH}/error.log')
         },
         'formatters': {
             'default': {
@@ -202,11 +202,11 @@ def main():
     if Config.ALLOW_INFO_LOG:
         log_dict['root']['handlers'].append('info_file')
         log_dict['handlers']['info_file'] = generate_log_file_dict(
-            'INFO', f'{Config.LOG_BASE_DIR}/info.log')
+            'INFO', f'{Config.LOG_FOLDER_PATH}/info.log')
     if Config.ALLOW_WARNING_LOG:
         log_dict['root']['handlers'].append('warning_file')
         log_dict['handlers']['warning_file'] = generate_log_file_dict(
-            'WARNING', f'{Config.LOG_BASE_DIR}/warning.log')
+            'WARNING', f'{Config.LOG_FOLDER_PATH}/warning.log')
 
     dictConfig(log_dict)
 


### PR DESCRIPTION
I'm deploying this server using [nix](https://nixos.org/). As a result, the source code lives on a readonly filesystem. I wanted to be able to decouple the state of the app (the stuff in the `./database` and `./log` directories) from the source code. All changes introduced are backwards compatible. That is, any existing instance of the server should keep working without making any changes.

Here's the changes I made:

1. Allowed configuring the location of the lephon_nell map via the config (right now, it is the only one that is hardcoded, which I found weird)
2. Allow customizing the location of the `log` directory via the config
3. Allow customizing the config path via an environment variable
4. Allow importing configs written as json instead of python (existing python configs will keep working). This is a feature I added in order for programmatically generating configs (via nix) or manipulating them (via `jq`) to work out of the box.

I'm already running off my own fork, but feel free to merge this is the changes seem useful :3
